### PR TITLE
Quote paths in post build events

### DIFF
--- a/src/Merger/asl-help-merger.csproj
+++ b/src/Merger/asl-help-merger.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="set out=$(TargetDir)&#xD;&#xA;set /p lsdir=&lt;..\..\.lsdir&#xD;&#xA;&#xD;&#xA;ilmerge /ndebug /out:%25out%25\asl-help-final.dll ^&#xD;&#xA;    %25out%25\asl-help.dll ^&#xD;&#xA;    %25out%25\asl-help-unity.dll ^&#xD;&#xA;    %25out%25\asl-help-core.dll&#xD;&#xA;&#xD;&#xA;copy %25out%25\asl-help-final.dll ..\..\lib\asl-help&#xD;&#xA;&#xD;&#xA;if exist %25lsdir%25\Components\ (&#xD;&#xA;    copy %25out%25\asl-help-final.dll %25lsdir%25\Components\asl-help&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;del %25out%25\asl-help-core.dll&#xD;&#xA;del %25out%25\asl-help-final.dll&#xD;&#xA;del %25out%25\LiveSplit.Core.dll" />
+    <Exec Command="set out=$(TargetDir)&#xD;&#xA;set /p lsdir=&lt;..\..\.lsdir&#xD;&#xA;&#xD;&#xA;ilmerge /ndebug /out:&quot;%25out%25\asl-help-final.dll&quot; ^&#xD;&#xA;    &quot;%25out%25\asl-help.dll&quot; ^&#xD;&#xA;    &quot;%25out%25\asl-help-unity.dll&quot; ^&#xD;&#xA;    &quot;%25out%25\asl-help-core.dll&quot;&#xD;&#xA;&#xD;&#xA;copy &quot;%25out%25\asl-help-final.dll&quot; ..\..\lib\asl-help&#xD;&#xA;&#xD;&#xA;if exist &quot;%25lsdir%25\Components\&quot; (&#xD;&#xA;    copy &quot;%25out%25\asl-help-final.dll&quot; &quot;%25lsdir%25\Components\asl-help&quot;&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;del &quot;%25out%25\asl-help-core.dll&quot;&#xD;&#xA;del &quot;%25out%25\asl-help-final.dll&quot;&#xD;&#xA;del &quot;%25out%25\LiveSplit.Core.dll&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
# Description
I have spaces in my filepath, this script fails because the paths are unquoted.

# Testing
Before:
```
>dotnet build
MSBuild version 17.9.8+b34f75857 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
  asl-help -> C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Merger\bin\net481\asl-help.dll
  asl-help-unity -> C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Merger\bin\net481\asl-help-unity.dll
  asl-help-merger -> C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Merger\bin\net481\asl-help-merger.dll
  An exception occurred during merging:
  ILMerge.Merge: /target not specified, but output file, 'C:\Users\Mitchell\Documents\development\autosplitter', has a different extension than the primary assemb
  ly, 'repos\asl-help\src\Merger\bin\net481\\asl-help-final.dll'.
     at ILMerging.ILMerge.Merge()
     at ILMerging.ILMerge.Main(String[] args)
  The system cannot find the file specified.
  The system cannot find the file specified.
  The system cannot find the path specified.
  The system cannot find the path specified.
  The system cannot find the path specified.
```

After:
```
>dotnet build
MSBuild version 17.9.8+b34f75857 for .NET
  Determining projects to restore...
  Restored C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Merger\asl-help-merger.csproj (in 83 ms).
  Restored C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Basic\asl-help.csproj (in 83 ms).
  Restored C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Unity\asl-help-unity.csproj (in 83 ms).
  asl-help -> C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Merger\bin\net481\asl-help.dll
  asl-help-unity -> C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Merger\bin\net481\asl-help-unity.dll
  asl-help-merger -> C:\Users\Mitchell\Documents\development\autosplitter repos\asl-help\src\Merger\bin\net481\asl-help-merger.dll
          1 file(s) copied.
          1 file(s) copied.

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:03.89
```

# Risk
n/a this is local dev loop only

---
- [x] I have read and accept asl-help's license.
